### PR TITLE
Fix find_tags_to_copy in images without latest tag

### DIFF
--- a/ecr_mirror/__init__.py
+++ b/ecr_mirror/__init__.py
@@ -159,9 +159,9 @@ def find_tags_to_copy(image_name, tag_patterns):
     Use Skopeo to list all available tags for an image
     """
     output = subprocess.check_output(
-        ["skopeo", "inspect", f"docker://{image_name}", "--override-os=linux"]
+        ["skopeo", "list-tags", f"docker://{image_name}", "--override-os=linux"]
     )
-    all_tags = json.loads(output)["RepoTags"]
+    all_tags = json.loads(output)["Tags"]
 
     if not tag_patterns:
         return all_tags


### PR DESCRIPTION
`skopeo inspect` is used to describe lower level details of a given image.
As a result, it default to the latest tag if none is passed. In images
that don't have a latest tag defined, skopeo will fail.

`skopeo list-tags` doesn't actually touch on image tags and doesn't suffer
the same problem.